### PR TITLE
Multi lingual product

### DIFF
--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -6,19 +6,27 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use App\Traits\MultiLanguage; 
 
 class Product extends Model
 {
-    use HasFactory;
+    use HasFactory, MultiLanguage;
 
     protected $fillable = [
         'category_id', 
-        'name', 
+        'name_en',
+        'name_ar', 
         'price', 
         'old_price', 
-        'description', 
+        'description_en', 
+        'description_ar',
         'slug', 
         'is_active'
+    ];
+
+    protected $multi_lang = [
+        'name',
+        'description'
     ];
 
     public function category() : BelongsTo {

--- a/app/Traits/MultiLanguage.php
+++ b/app/Traits/MultiLanguage.php
@@ -1,0 +1,22 @@
+<?php 
+
+namespace App\Traits; 
+
+use Illuminate\Support\Facades\App;
+
+trait MultiLanguage
+{
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        if(isset($this->multi_lang) && in_array($key, $this->multi_lang))
+        {
+            $key = $key . "_" . App::getLocale();
+        }
+        return parent::__get($key);
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -17,10 +17,12 @@ class ProductFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->firstNameMale(), 
+            'name_en' => $this->faker->firstNameMale(), 
+            'name_ar' => "غير مهم",
             'price' => $this->faker->randomFloat(),
             'old_price' => $this->faker->randomFloat(), 
-            'description' => $this->faker->paragraph(),
+            'description_en' => $this->faker->paragraph(),
+            'description_ar' => 'غير مهم اخر', 
             'slug' => $this->faker->word(), 
             'is_active' => true
         ];

--- a/database/migrations/2023_11_30_122415_create_products_table.php
+++ b/database/migrations/2023_11_30_122415_create_products_table.php
@@ -14,10 +14,12 @@ return new class extends Migration
         Schema::create('products', function (Blueprint $table) {
             $table->id();
             $table->foreignId('category_id'); 
-            $table->string('name'); 
+            $table->string('name_en'); 
+            $table->string('name_ar'); 
             $table->float('price'); 
             $table->float('old_price'); 
-            $table->longText('description');
+            $table->longText('description_en');
+            $table->longText('description_ar');
             $table->string('slug'); 
             $table->boolean('is_active'); 
             $table->timestamps();


### PR DESCRIPTION
In this branch, I worked on providing multi-lingual support for the Product model. What I did is that I created a new trait called MultiLanguage to be used inside any model. What it does is that it takes the corresponding attributes in the multi_lang array and adds a suffix to them by examining the user's current locale, and this has been done by overriding __get() behavior. 
In this implementation, the model will have one column for each language. The drawback is that the number of columns will increase with the number of needed languages  (which wouldn't be the case in our system). 